### PR TITLE
`gh` CLI requires the `GH_TOKEN` to be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ jobs:
       - name: Deploy nerves_system
         uses: ./.actions/deploy-system
         with:
-          github-token: ${{ secrets.ARTIFACT_GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ## Setup for use
@@ -229,7 +229,19 @@ The `./.actions/deploy-system` action should only be run after a job running the
       - uses: gridpoint-com/actions-nerves-system@v1
       - name: Deploy nerves_system
         uses: ./.actions/deploy-system
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+> [!NOTE]
+> `GITHUB_TOKEN` is provided in every action as a secret which needs
+> to be passed to the job using it via `${{ secrets.GITHUB_TOKEN }}`
+> You can also control the permissions for it which must be
+> `contents: write` in order to create the release
+>
+> See docs for more info:
+> * https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-github-cli-in-workflows
+> * https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token 
 
 ### Creating a release
 

--- a/deploy-system/action.yml
+++ b/deploy-system/action.yml
@@ -1,5 +1,17 @@
 name: deploy-system
 
+inputs:
+  github-token:
+    description: |
+      GitHub token for creating releases. GITHUB_TOKEN is set for every action
+      and can be passed as an input to this action. You will also need to set
+      the `contents: write` permission for the token.
+
+      See docs for more info:
+      * https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-github-cli-in-workflows
+      * https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token 
+    required: true
+
 runs:
   using: composite
   steps:
@@ -16,5 +28,7 @@ runs:
         echo "$(< deploy/system/RELEASE_NOTES)"
     - name: Deploy artifacts to Github
       shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
       run: |
         gh release create ${{ github.ref_name }} deploy/system/artifacts --title ${{ github.ref_name }} -F deploy/system/RELEASE_NOTES --draft


### PR DESCRIPTION
I thought this was automatically included, but it is actually required to set for the job when wanting to use the `gh` CLI.

So this adds back `github-token` as a required input so that it fails if the user does not provide it and docs for how to set it. The user can use the `GITHUB_TOKEN` that is automatically set for each action instead of having to manually create their own