### PR TITLE
Wildcard deploy artifacts directory

### DIFF
--- a/deploy-system/action.yml
+++ b/deploy-system/action.yml
@@ -31,4 +31,4 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.github-token }}
       run: |
-        gh release create ${{ github.ref_name }} deploy/system/artifacts --title ${{ github.ref_name }} -F deploy/system/RELEASE_NOTES --draft
+        gh release create ${{ github.ref_name }} deploy/system/artifacts/* --title ${{ github.ref_name }} -F deploy/system/RELEASE_NOTES --draft


### PR DESCRIPTION
`ghr` accepted a directory for upload but `gh` requires a list of files. However, it supports a wildcard in the path, so this adds that to the artifacts path to upload the built artifacts