### PR TITLE
Bump GitHub Actions to fix Node.js 20 deprecation warnings

### DIFF
--- a/.internal/cache-buildroot-ccache/action.yml
+++ b/.internal/cache-buildroot-ccache/action.yml
@@ -13,7 +13,7 @@ runs:
         done
         ls -l .toolchains/
     - name: Cache the buildroot ccache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/.buildroot-ccache
         key: buildroot-ccache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.toolchains/') }}

--- a/.internal/push-to-download-site/action.yml
+++ b/.internal/push-to-download-site/action.yml
@@ -24,7 +24,7 @@ runs:
           BR2_BACKUP_SITE=http://sources.buildroot.net \
           source
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: ${{ inputs.aws-role }}
         aws-region: ${{ inputs.aws-region }}

--- a/.internal/restore-nerves-downloads/action.yml
+++ b/.internal/restore-nerves-downloads/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Restore nerves downloads
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v6
       with:
         path: ~/.nerves/dl
         key: nerves-dl-${{ github.ref_name }}-${{ github.sha }}

--- a/build-system/action.yml
+++ b/build-system/action.yml
@@ -64,12 +64,12 @@ runs:
         cp ./CHANGELOG.md deploy/system/CHANGELOG.md
         mix nerves.artifact ${GITHUB_REPOSITORY#*/} --path deploy/system/artifacts
     - name: Store artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         path: deploy/system/artifacts
         name: system
     - name: Save deploy cache
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v6
       with:
         path: deploy/system
         key: deploy/system-${{ github.sha }}-${{ github.ref_name }}

--- a/deploy-system/action.yml
+++ b/deploy-system/action.yml
@@ -16,7 +16,7 @@ runs:
   using: composite
   steps:
     - name: Restore cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v6
       with:
         path: deploy/system
         key: deploy/system-${{ github.sha }}-${{ github.ref_name }}

--- a/get-br-dependencies/action.yml
+++ b/get-br-dependencies/action.yml
@@ -68,7 +68,7 @@ runs:
         aws-region: ${{ inputs.aws-region }}
     - name: Save Nerves downloads
       if: inputs.save-dl-cache == 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v6
       with:
         path: ~/.nerves/dl
         key: nerves-dl-${{ github.ref_name }}-${{ github.sha }}


### PR DESCRIPTION
## Summary
- Bumps `actions/cache` from v4 to v6
- Bumps `aws-actions/configure-aws-credentials` from v4 to v6
- Bumps `actions/upload-artifact` from v4 to v7

All updated actions target Node.js 24+, eliminating the deprecation warnings.

Closes #7